### PR TITLE
Now only run for pushes to master or pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,11 @@
 
 name: Tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
   
 
 jobs:


### PR DESCRIPTION
This stops running the Ci twice as much for no reason