### PR TITLE
Enable GC Safe mode

### DIFF
--- a/src/taskman.nim
+++ b/src/taskman.nim
@@ -213,7 +213,7 @@ proc defaultErrorHandler[T: HandlerTypes](tasks: SchedulerBase[T], task: TaskBas
   ## Default error handler, just raises the error further up the stack
   raise exception
 
-proc newSchedulerBase[T: HandlerTypes](errorHandler: ErrorHandler[T]): SchedulerBase[T] =
+proc newSchedulerBase*[T: HandlerTypes](errorHandler: ErrorHandler[T] = defaultErrorHandler[T]): SchedulerBase[T] =
   SchedulerBase[T](
     tasks: initHeapQueue[TaskBase[T]](),
     errorHandler: errorHandler
@@ -414,7 +414,7 @@ template onlyRun*(times: int) =
     else:
       inc timesRan
 
-proc start*(scheduler: AsyncScheduler | Scheduler, periodicCheck = 0) {.multisync.} =
+proc start*(scheduler: AsyncScheduler | Scheduler, periodicCheck = 0) =
   ## Starts running the tasks.
   ## Call with `asyncCheck` to make it run in the background
   ##
@@ -423,7 +423,7 @@ proc start*(scheduler: AsyncScheduler | Scheduler, periodicCheck = 0) {.multisyn
   scheduler.running = true
   while scheduler.len > 0 or periodicCheck > 0:
     if scheduler.len == 0:
-      when isAsync:
+      when not isAsync:
         await sleepAsync(periodicCheck)
       else:
         sleep periodicCheck

--- a/src/taskman.nim
+++ b/src/taskman.nim
@@ -216,11 +216,15 @@ proc defaultErrorHandler[T: HandlerTypes](tasks: SchedulerBase[T], task: TaskBas
   ## Default error handler, just raises the error further up the stack
   raise exception
 
-proc newSchedulerBase*[T: HandlerTypes](errorHandler: ErrorHandler[T] = defaultErrorHandler[T]): SchedulerBase[T] =
-  ## Creates a new scheduler that calls procs of `T`. Only use this if you want to add extra restriction to the proc type (exceptions, gcsafe, etc)
+proc newSchedulerBase*[T: HandlerTypes](errorHandler: ErrorHandler[T] = nil): SchedulerBase[T] =
+  ## Creates a new scheduler that calls procs of `T`. Only use this if you want to add extra restriction to the proc type (exceptions, gcsafe, etc).
+  ##
+  ## * **errorHandler**: Proc that is called when exceptions are raised in tasks. By default it just reraises exceptions
   SchedulerBase[T](
     tasks: initHeapQueue[TaskBase[T]](),
-    errorHandler: errorHandler
+    # Generic bug that is fixed on devel.
+    # T isn't available in default params so we can't instantiate the default handler.
+    errorHandler: if errorHandler != nil: errorHandler else: defaultErrorHandler[T]
   )
 
 proc newScheduler*(errorHandler: ErrorHandler[TaskHandler] = defaultErrorHandler[TaskHandler]): Scheduler =

--- a/src/taskman.nim
+++ b/src/taskman.nim
@@ -209,11 +209,12 @@ proc wakeUp[T](tasks: SchedulerBase[T]) =
 func `<`(a, b: TaskBase): bool {.inline.} = a.startTime < b.startTime
 func `==`(a, b: TaskBase): bool {.inline.} = a.handler == b.handler
 
-proc defaultErrorHandler[T](tasks: SchedulerBase[T], task: TaskBase[T],  exception: ref Exception) =
+proc defaultErrorHandler[T: HandlerTypes](tasks: SchedulerBase[T], task: TaskBase[T],  exception: ref Exception) =
   ## Default error handler, just raises the error further up the stack
   raise exception
 
-proc newSchedulerBase*[T](errorHandler: ErrorHandler[T] = defaultErrorHandler[T]): SchedulerBase[T] =
+proc newSchedulerBase*[T: HandlerTypes](errorHandler: ErrorHandler[T] = defaultErrorHandler[T]): SchedulerBase[T] =
+  ## Creates a new scheduler that calls procs of `T` (which can't)
   SchedulerBase[T](
     tasks: initHeapQueue[TaskBase[T]](),
     errorHandler: errorHandler
@@ -243,7 +244,7 @@ proc len*(scheduler: SchedulerBase): int {.inline.} =
   ## Returns number of tasks in the scheduler
   scheduler.tasks.len
 
-proc newTask*[T](interval: TimeInterval, handler: T, name = defaultTaskName): TaskBase[T] =
+proc newTask*[T: HandlerTypes](interval: TimeInterval, handler: T, name = defaultTaskName): TaskBase[T] =
   ## Creates a new task which can be added to a scheduler.
   ## This task will run every `interval`
   TaskBase[T](

--- a/src/taskman.nim
+++ b/src/taskman.nim
@@ -203,11 +203,14 @@ proc wakeUp[T](tasks: SchedulerBase[T]) =
       tasks.timer.fut.complete()
       # Disarm the timer
       tasks.timer.fut = nil
-  else:
-    discard
 
-func `<`(a, b: TaskBase): bool {.inline.} = a.startTime < b.startTime
-func `==`(a, b: TaskBase): bool {.inline.} = a.handler == b.handler
+func `<`*[T](a, b: TaskBase[T]): bool {.inline.} =
+  ## Checks if one task is scheduled before another
+  a.startTime < b.startTime
+
+func `==`*[T](a, b: TaskBase[T]): bool {.inline.} =
+  ## Two handlers are considered equal if they have the same handler
+  a.handler == b.handler
 
 proc defaultErrorHandler[T: HandlerTypes](tasks: SchedulerBase[T], task: TaskBase[T],  exception: ref Exception) =
   ## Default error handler, just raises the error further up the stack
@@ -464,7 +467,6 @@ proc start*[T: AsyncTaskHandler](scheduler: SchedulerBase[T], periodicCheck = 0)
       continue # Run loop again to check if stuff has been added while sleeping
 
     let sleepTime = scheduler.tasks[0].milliSecondsLeft
-
     # This is more or less copy and pasted from async dispatch.
     # But we make a few modifications so that we can effectively cancel the sleeping.
     # This enables us to force the scheduler to check for new tasks when they get added (Instead of needing to poll with periodicCheck)

--- a/tests/testTaskman.nim
+++ b/tests/testTaskman.nim
@@ -106,6 +106,18 @@ test "Can use a closure":
   tasks.every(1.seconds) do () {.async.}:
     echo x
 
+test "Can work gcsafe":
+  proc mustBeSafe() {.gcsafe.} =
+    let tasks = newSchedulerBase[proc () {.gcsafe.}]()
+    # let tasks = newScheduler()
+
+    tasks.every(1.seconds) do () {.gcsafe.}:
+      discard
+    if false:
+      tasks.start()
+
+  mustBeSafe()
+
 when defined(testCron):
   # Since it takes minimum 1 for a cron task to run we will put it behind a flag
   suite "Cron":


### PR DESCRIPTION
Small cleanup to internals.  Fixe #7 

Exposes `newSchedulerBase` which allows for restricting the proc type to how you want it (This then allows for restricting effects, exceptions, etc).

The `start` is then broken up into async/sync version (there were a lot of `when` statements anyways). This is to get around `multisync` needing me to specify the two different versions which locked the tasks being non gcsafe (Since thats what the types were specified as).

Want to clean up the code a bit more first though